### PR TITLE
Added the setup to activateMenu to get the table name

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -76,7 +76,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $this->createMenuItem('menu-item-1', 'Menu item 1', $id);
             $this->createMenuItem('menu-item-2', 'Menu item 2', $id);
             $this->createMenuItem('scandiweb', 'Scandiweb', $id);
-            $this->activateMenu($id);
+            $this->activateMenu($setup, $id);
         }
 
         $setup->endSetup();
@@ -127,10 +127,11 @@ class UpgradeSchema implements UpgradeSchemaInterface
 
     /**
      * @param $id
+     * @param $setup
      */
-    public function activateMenu($id) {
-        $tableName = 'scandiweb_menumanager_menu_store';
-        $mainTable = 'scandiweb_menumanager_menu';
+    public function activateMenu($setup, $id) {
+        $tableName = $setup->getTable('scandiweb_menumanager_menu_store');
+        $mainTable = $setup->getTable('scandiweb_menumanager_menu');
         $connection = ObjectManager::getInstance()->get('Magento\Framework\App\ResourceConnection')->getConnection();
         $sql = "INSERT INTO " . $tableName . " (menu_id, store_id) values 
                 ((select menu_id from " . $mainTable . " where " . $mainTable .".menu_id = " . $id . "), 0)";


### PR DESCRIPTION
This prevents the UpgradeSchema from failing whenever there is a prefix set during Magento 2 Setup.

Recently I've came across an installation of Magento 2 for which I had a random table prefix set during the setup. The menu-manager crashed during the setup:upgrade. Went looking to find that the getTable function was never used to access tables.

Fixed that for you, should work now :smile: 

Let me know if something needs changing.